### PR TITLE
Add Kensa data record editing to DenshiEditor

### DIFF
--- a/packages/frontend/src/lib/denshi-editor/DenshiEditor.svelte
+++ b/packages/frontend/src/lib/denshi-editor/DenshiEditor.svelte
@@ -35,6 +35,7 @@
   import ChevronDownLink from "./icons/ChevronDownLink.svelte";
   import ChevronUpLink from "./icons/ChevronUpLink.svelte";
   import InfoProviders from "./InfoProviders.svelte";
+  import KensaValues from "./KensaValues.svelte";
   import Bikou from "./Bikou.svelte";
 
   export let destroy: () => void;
@@ -283,6 +284,45 @@
     clearForm = () => e.$destroy();
   }
 
+  function doAddKensa() {
+    clearForm();
+    const e: KensaValues = new KensaValues({
+      target: formElement,
+      props: {
+        検査値データ等レコード: [
+          ...検査値データ等レコード,
+          index検査値データ等レコード({ 検査値データ等: "" }),
+        ],
+        onDone: () => {
+          clearForm();
+          clearForm = () => {};
+        },
+        onChange: (data) => {
+          検査値データ等レコード = data;
+        },
+      },
+    });
+    clearForm = () => e.$destroy();
+  }
+
+  function doEditKensa() {
+    clearForm();
+    const e: KensaValues = new KensaValues({
+      target: formElement,
+      props: {
+        検査値データ等レコード,
+        onDone: () => {
+          clearForm();
+          clearForm = () => {};
+        },
+        onChange: (data) => {
+          検査値データ等レコード = data;
+        },
+      },
+    });
+    clearForm = () => e.$destroy();
+  }
+
   function doAddBikou() {
     clearForm();
     const e: Bikou = new Bikou({
@@ -366,6 +406,13 @@
               on:click={doAddInfoProvider}
             >
               情報提供
+            </a>
+            <a
+              href="javascript:void(0)"
+              class="small-link"
+              on:click={doAddKensa}
+            >
+              検査値
             </a>
             <a
               href="javascript:void(0)"

--- a/packages/frontend/src/lib/denshi-editor/KensaValues.svelte
+++ b/packages/frontend/src/lib/denshi-editor/KensaValues.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+  import type { 検査値データ等レコードIndexed } from "./denshi-editor-types";
+  import CancelLink from "./icons/CancelLink.svelte";
+  import SubmitLink from "./icons/SubmitLink.svelte";
+  import TrashLink from "./icons/TrashLink.svelte";
+
+  export let 検査値データ等レコード: 検査値データ等レコードIndexed[];
+  export let onDone: () => void;
+  export let onChange: (records: 検査値データ等レコードIndexed[]) => void;
+
+  function doNotice() {
+    let isEditing = 検査値データ等レコード.some(rec => rec.isEditing);
+    if (isEditing) {
+      alert("編集中のレコードがあります。保存してください。");
+      return;
+    }
+    onDone();
+    onChange(検査値データ等レコード);
+  }
+
+  function doEnter(rec: 検査値データ等レコードIndexed) {
+    if (rec.検査値データ等.trim() === "") {
+      alert("検査値データ等が入力されていません。");
+      return;
+    }
+    rec.orig = { 検査値データ等: rec.検査値データ等 };
+    rec.isEditing = false;
+    検査値データ等レコード = 検査値データ等レコード;
+  }
+
+  function doDelete(rec: 検査値データ等レコードIndexed) {
+    検査値データ等レコード = 検査値データ等レコード.filter(r => r.id !== rec.id);
+  }
+
+  function doEdit(rec: 検査値データ等レコードIndexed) {
+    rec.isEditing = true;
+    検査値データ等レコード = 検査値データ等レコード;
+  }
+
+  function doCancel(rec: 検査値データ等レコードIndexed) {
+    rec.検査値データ等 = rec.orig.検査値データ等;
+    rec.isEditing = false;
+    検査値データ等レコード = 検査値データ等レコード;
+  }
+</script>
+
+<div>検査値データ等</div>
+{#each 検査値データ等レコード as rec (rec.id)}
+  {#if rec.isEditing}
+    <form on:submit|preventDefault={() => doEnter(rec)}>
+      <input type="text" bind:value={rec.検査値データ等} />
+      {#if rec.検査値データ等.trim() !== ""}
+        <SubmitLink onClick={() => doEnter(rec)} />
+      {/if}
+      <TrashLink onClick={() => doDelete(rec)} />
+      {#if rec.orig.検査値データ等 !== ""}
+        <CancelLink onClick={() => doCancel(rec)} style="left:-4px;" />
+      {/if}
+    </form>
+  {:else}
+    <div>
+      <!-- svelte-ignore a11y-no-static-element-interactions -->
+      <span class="editable" on:click={() => doEdit(rec)}>{rec.検査値データ等}</span>
+      <TrashLink onClick={() => doDelete(rec)} />
+    </div>
+  {/if}
+{/each}
+
+<div class="commands">
+  <button on:click={doNotice}>入力</button>
+  <button on:click={onDone}>キャンセル</button>
+</div>
+
+<style>
+  .editable {
+    cursor: pointer;
+  }
+
+  .commands {
+    text-align: right;
+    padding: 10px;
+  }
+</style>


### PR DESCRIPTION
## Summary
- add `KensaValues.svelte` to edit 検査値データ等レコード
- import and use the new component in `DenshiEditor.svelte`
- allow adding 検査値 records from the auxiliary menu

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541be1a59c8325bf0216f2af775879